### PR TITLE
feat: add Supervised Fine-Tuning (SFT) course module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+sft_workspace/

--- a/src/content/snippets/sft-dataset.py
+++ b/src/content/snippets/sft-dataset.py
@@ -1,0 +1,41 @@
+from transformers import AutoTokenizer
+from datasets import Dataset
+
+tokenizer = AutoTokenizer.from_pretrained("gpt2")
+tokenizer.pad_token = tokenizer.eos_token
+
+# Template ChatML (geralmente já vem no tokenizer de modelos instruídos)
+chatml_template = (
+    "{% for message in messages %}"
+    "{{'<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|im_start|>assistant\\n' }}"
+    "{% endif %}"
+)
+tokenizer.chat_template = chatml_template
+tokenizer.add_special_tokens({"additional_special_tokens": ["<|im_start|>", "<|im_end|>"]})
+
+# Nosso Dataset de perguntas e respostas em Português
+data = [
+    {"messages": [
+        {"role": "system", "content": "Você é um assistente prestativo."},
+        {"role": "user", "content": "Qual é a capital do Brasil?"},
+        {"role": "assistant", "content": "A capital do Brasil é Brasília."}
+    ]},
+    {"messages": [
+        {"role": "system", "content": "Você é um assistente prestativo."},
+        {"role": "user", "content": "Quem escreveu Dom Casmurro?"},
+        {"role": "assistant", "content": "Dom Casmurro foi escrito por Machado de Assis."}
+    ]}
+]
+
+# Função para aplicar o template ChatML e tokenizar
+def format_dataset(example):
+    text = tokenizer.apply_chat_template(example["messages"], tokenize=False)
+    encodings = tokenizer(text, truncation=True, max_length=128, padding="max_length")
+    encodings["labels"] = encodings["input_ids"].copy()
+    return encodings
+
+dataset = Dataset.from_list(data)
+tokenized_dataset = dataset.map(format_dataset, remove_columns=["messages"])

--- a/src/content/snippets/sft-dataset.py.meta.json
+++ b/src/content/snippets/sft-dataset.py.meta.json
@@ -1,0 +1,21 @@
+{
+  "language": "python",
+  "explanations": [
+    {
+      "lineRange": [4, 5],
+      "description": "Carregamos o tokenizador base."
+    },
+    {
+      "lineRange": [7, 18],
+      "description": "Definimos o template ChatML. Modelos como Llama-3 ou Qwen já vêm com isso por padrão."
+    },
+    {
+      "lineRange": [20, 31],
+      "description": "Nosso conjunto de dados contendo o papel de cada mensagem."
+    },
+    {
+      "lineRange": [33, 41],
+      "description": "Usamos a biblioteca `datasets` para iterar, injetar o ChatML e tokenizar."
+    }
+  ]
+}

--- a/src/content/snippets/sft-generate.py
+++ b/src/content/snippets/sft-generate.py
@@ -1,0 +1,29 @@
+# Uma nova pergunta para o modelo, já no formato de lista de dicionários
+prompt_messages = [
+    {"role": "system", "content": "Você é um assistente prestativo."},
+    {"role": "user", "content": "Qual é a capital do Brasil?"}
+]
+
+# Aplicamos o template ChatML, mas ATENÇÃO:
+# add_generation_prompt=True faz o tokenizer adicionar '<|im_start|>assistant' no final
+prompt_text = tokenizer.apply_chat_template(
+    prompt_messages,
+    tokenize=False,
+    add_generation_prompt=True
+)
+
+inputs = tokenizer(prompt_text, return_tensors="pt").to(model.device)
+
+# Geramos a resposta
+outputs = model.generate(
+    **inputs,
+    max_new_tokens=20,
+    do_sample=False,  # Sem aleatoriedade, queremos a resposta exata
+    pad_token_id=tokenizer.eos_token_id
+)
+
+response = tokenizer.decode(outputs[0], skip_special_tokens=False)
+
+print("\\n--- RESPOSTA DO ASSISTENTE ---")
+print(response)
+print("------------------------------")

--- a/src/content/snippets/sft-generate.py.meta.json
+++ b/src/content/snippets/sft-generate.py.meta.json
@@ -1,0 +1,21 @@
+{
+  "language": "python",
+  "explanations": [
+    {
+      "lineRange": [1, 5],
+      "description": "Nossa nova entrada para o modelo, já no formato de lista de dicionários padrão de APIs."
+    },
+    {
+      "lineRange": [7, 13],
+      "description": "Crucial: `add_generation_prompt=True` garante que o modelo começará a gerar texto logo após receber o marcador `<|im_start|>assistant\\n`."
+    },
+    {
+      "lineRange": [15, 15],
+      "description": "Transformamos o texto ChatML final em tensores."
+    },
+    {
+      "lineRange": [17, 25],
+      "description": "Geramos a resposta e a decodificamos."
+    }
+  ]
+}

--- a/src/content/snippets/sft-train.py
+++ b/src/content/snippets/sft-train.py
@@ -1,0 +1,30 @@
+from transformers import AutoModelForCausalLM, TrainingArguments, Trainer
+
+# Carregando o modelo pré-treinado
+model_name = "gpt2"
+model = AutoModelForCausalLM.from_pretrained(model_name)
+
+# Precisamos ajustar o tamanho dos embeddings pois adicionamos
+# tokens novos (<|im_start|>, <|im_end|>) no tokenizador anteriormente
+model.resize_token_embeddings(len(tokenizer))
+
+# Parâmetros de treinamento
+training_args = TrainingArguments(
+    output_dir="./sft_output",
+    num_train_epochs=30,      # Treinamos bastante para ele decorar este exemplo simples
+    per_device_train_batch_size=2,
+    logging_steps=5,
+    learning_rate=5e-4,
+    save_strategy="no",       # Para este exemplo não salvaremos checkpoints
+    report_to="none"          # Desabilita integrações externas de logging
+)
+
+# O Trainer facilita o loop de treinamento
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=tokenized_dataset,
+)
+
+print("Iniciando Treinamento SFT...")
+trainer.train()

--- a/src/content/snippets/sft-train.py.meta.json
+++ b/src/content/snippets/sft-train.py.meta.json
@@ -1,0 +1,21 @@
+{
+  "language": "python",
+  "explanations": [
+    {
+      "lineRange": [4, 5],
+      "description": "Carregamos o modelo base de Text Completion."
+    },
+    {
+      "lineRange": [7, 9],
+      "description": "Redimensionamos a camada de embeddings para suportar os novos tokens `<|im_start|>` e `<|im_end|>` que criamos no passo anterior."
+    },
+    {
+      "lineRange": [11, 20],
+      "description": "Definimos os hiperparâmetros de treinamento. Usamos 30 épocas para que o modelo memorize perfeitamente o formato neste exemplo em miniatura."
+    },
+    {
+      "lineRange": [22, 29],
+      "description": "Inicializamos e rodamos o Trainer, que processa os cálculos de perda (loss) de forma automática usando Cross-Entropy."
+    }
+  ]
+}

--- a/src/data/course-outline.ts
+++ b/src/data/course-outline.ts
@@ -102,4 +102,8 @@ export const courseSlideOrder = [
   'build-gpt2-model',
   'build-gpt2-train',
   'build-gpt2-generate',
+  'sft-intro',
+  'sft-dataset',
+  'sft-train',
+  'sft-generate',
 ] as const;

--- a/src/data/slides/sft-dataset.json
+++ b/src/data/slides/sft-dataset.json
@@ -1,0 +1,12 @@
+{
+  "title": "Preparando o Dataset de Diálogo",
+  "content": [
+    "Para ensinar o modelo a conversar, precisamos de um conjunto de dados de diálogos organizados. Na indústria, usamos a biblioteca `datasets` da Hugging Face.",
+    "Criaremos um dataset com exemplos em Português, contendo papéis de `system`, `user` e `assistant`.",
+    "O `tokenizer.apply_chat_template` se encarrega de injetar os tokens ChatML corretos automaticamente no nosso texto."
+  ],
+  "visualType": "code",
+  "visualProps": {
+    "snippetId": "sft-dataset"
+  }
+}

--- a/src/data/slides/sft-generate.json
+++ b/src/data/slides/sft-generate.json
@@ -1,0 +1,12 @@
+{
+  "title": "Testando o Assistente",
+  "content": [
+    "Após o treinamento, o modelo não apenas prevê texto aleatório, ele continua a conversa a partir do padrão que aprendeu.",
+    "Nós enviamos o `system` e o `user` formatados, e adicionamos `add_generation_prompt=True` para o tokenizador inserir o início do assistente (`<|im_start|>assistant\\n`).",
+    "O modelo então gera a resposta desejada, finalizando a nossa criação de um assistente de IA!"
+  ],
+  "visualType": "code",
+  "visualProps": {
+    "snippetId": "sft-generate"
+  }
+}

--- a/src/data/slides/sft-intro.json
+++ b/src/data/slides/sft-intro.json
@@ -1,0 +1,26 @@
+{
+  "title": "A Evolução para SFT e ChatML",
+  "content": [
+    "Até agora, construímos um modelo que prevê a próxima palavra (Text Completion). Mas como transformar isso em um assistente que responde perguntas?",
+    "A resposta é o **SFT (Supervised Fine-Tuning)**. Consiste em pegar um modelo pré-treinado e continuar treinando-o em exemplos estruturados de conversas.",
+    "Para isso, precisamos de um formato de dados consistente. O **ChatML** é um formato padrão para representar diálogos. Ele utiliza tokens especiais como `<|im_start|>` e `<|im_end|>` para separar papéis (sistema, usuário, assistente)."
+  ],
+  "visualType": "layout",
+  "visualProps": {
+    "sections": [
+      {
+        "title": "Text Completion (Base)",
+        "content": "\"Qual é a capital do Brasil? A capital do Brasil...\"",
+        "type": "block",
+        "icon": "Text"
+      },
+      {
+        "title": "ChatML (Formato de Diálogo)",
+        "content": "<|im_start|>user\\nQual é a capital do Brasil?<|im_end|>\\n<|im_start|>assistant\\nA capital do Brasil é Brasília.<|im_end|>",
+        "type": "block",
+        "icon": "MessageSquare"
+      }
+    ],
+    "orientation": "vertical"
+  }
+}

--- a/src/data/slides/sft-train.json
+++ b/src/data/slides/sft-train.json
@@ -1,0 +1,12 @@
+{
+  "title": "Treinamento Supervisionado (SFT)",
+  "content": [
+    "Agora que temos os dados formatados, usamos a classe `Trainer` da Hugging Face para o ajuste fino (fine-tuning).",
+    "Durante o SFT, o modelo tenta prever a próxima palavra, mas agora o texto tem a estrutura exata de uma conversa (pergunta e resposta).",
+    "Neste exemplo simples, treinamos um modelo pequeno (`gpt2`) por várias épocas (epochs) para ele decorar o formato e a resposta."
+  ],
+  "visualType": "code",
+  "visualProps": {
+    "snippetId": "sft-train"
+  }
+}


### PR DESCRIPTION
This commit introduces a new module on Supervised Fine-Tuning (SFT). It addresses the transition from base text completion models to instruction-following/chat assistants by utilizing ChatML. It includes practical examples using the Hugging Face `datasets` library for dataset loading and `Trainer` for fine-tuning. The snippets are designed to be fast and reproducible by overfitting a small dataset with Portuguese examples to guarantee coherent outputs.

---
*PR created automatically by Jules for task [2305841647813792574](https://jules.google.com/task/2305841647813792574) started by @celsowm*